### PR TITLE
Bugfix for --reveal-js option when installing with "python setup.py install"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include html5css3/rst2html5.css
+include html5css3/rst2html5-reveal.css
 recursive-include html5css3/thirdparty *


### PR DESCRIPTION
Hi, this will fix the MANIFEST.in file: it was missing the rst2html5-reveal.css file, which was not installed in site-packages/rst2html5-0.1.egg/html5css3/ directory
