### PR TITLE
remove col group

### DIFF
--- a/html5css3/__init__.py
+++ b/html5css3/__init__.py
@@ -293,7 +293,7 @@ NODES = {
     "table": Table,
     "tbody": Tbody,
     "term": Dt,
-    "tgroup": Colgroup,
+    "tgroup": skip,
     "thead": Thead,
     "title_reference": Cite,
     "transition": Hr,


### PR DESCRIPTION
colgroup and col are not of much use in conversion from RST. There is no RST syntax to change their attributes, nor is there any attributes you
would really want to modify. In any case, styling is CSS's job.
