### PR TITLE
fix placement of <span> tags for additional ids

### DIFF
--- a/html5css3/__init__.py
+++ b/html5css3/__init__.py
@@ -513,11 +513,11 @@ class HTMLTranslator(nodes.NodeVisitor):
         if ids:
             atts['id'] = ids[0]
 
+            # ids must be appended as first children to the tag
             for id in ids[1:]:
-                self.current.append(Span(id=id))
+                tag.append(Span(id=id))
 
         tag.attrib.update(atts)
-
 
     def pop_parent(self, node):
         self.current = self.parents.pop()
@@ -643,7 +643,8 @@ class HTMLTranslator(nodes.NodeVisitor):
         self._stack(tag, node)
 
     def visit_target(self, node):
-        self._stack(Span(class_="target"), node)
+        append_tag = not ('refuri' in node or 'refid' in node or 'refname' in node)
+        self._stack(Span(class_="target"), node, append_tag)
 
     def visit_author(self, node):
         if isinstance(self.current, Ul):


### PR DESCRIPTION
`rst2html5` places `<span>` tags containing additional IDs for a section incorrectly (after the closing `</section>` tag instead of right at the beginning of the `<section>`). Also, `rst2html5` creates unnecessary empty `<span>` tags after inline internal references. This patch fixes both issues.

To reproduce the issues, try filtering the following document through an unpatched `rst2html5`:

``` rst
.. _foo:

First section
-------------

Second section
--------------

Third section
-------------

`This link`_ should lead back to the first section but leads to the second
section instead using ``rst2html5``. It works as expected using ``rst2html``.

.. _This link: foo_
```

`rst2html5` produces the following HTML output (irrelevant parts omitted):

``` html
<span class="target"></span>
<section id="first-section">
    <header><h2>First section</h2></header>
</section>
<span id="foo"></span>
<section id="second-section">
    <header><h2>Second section</h2></header>
</section>
<section id="third-section">
    <header><h2>Third section</h2></header>
    <p>
        <a class="reference internal" href="#foo">This link</a> should lead back to the first section but leads to the second section instead using <code>rst2html5</code>. It works as expected using <code>rst2html</code>.
    </p>
    <span class="target" id="this-link"></span>
</section>
```

Note the misplaced `<span id="foo">` which appears before the second section and not before the first one. Also note the extra `<span class="target">` tags.

After patching `rst2html5` according to this pull request, the following (correct) output is produced:

``` html
<section id="first-section">
    <span id="foo"></span>
    <header><h2>First section</h2></header>
</section>

<section id="second-section">
    <header><h2>Second section</h2></header>
</section>

<section id="third-section">
    <header><h2>Third section</h2></header>
    <p>
        <a class="reference internal" href="#foo">This link</a> should lead back to the first section but leads to the second section instead using <code>rst2html5</code>. It works as expected using <code>rst2html</code>.
    </p>
</section>
```
