### PR TITLE
Insert default/custom css after the execution of postprocessors

### DIFF
--- a/html5css3/__init__.py
+++ b/html5css3/__init__.py
@@ -236,6 +236,10 @@ class Writer(writers.Writer):
 
                 processor(tree, embed, params)
 
+        # tell the visitor to append the default stylesheets
+        # we call it after the postprocessors to make sure it haves precedence
+        visitor.append_default_stylesheets()
+
         self.output = DOCTYPE
         self.output += str(tree)
 
@@ -461,6 +465,8 @@ class HTMLTranslator(nodes.NodeVisitor):
             Meta(charset=self.content_type),
             Title(self.title))
 
+    def append_default_stylesheets(self):
+        """ Appends the default styles defined on the translator settings. """
         styles = utils.get_stylesheet_list(self.settings)
 
         for style in styles:

--- a/html5css3/postprocessors.py
+++ b/html5css3/postprocessors.py
@@ -185,7 +185,6 @@ def bootstrap_css(tree, embed=True, params=None):
     head = tree[0]
 
     head.append(css(join_path("thirdparty", "bootstrap.css"), embed))
-    head.append(css("rst2html5.css", embed))
 
 def embed_images(tree, embed=True, params=None):
     import base64


### PR DESCRIPTION
Doing so gives the default styles or styles defined by the user precedence over any styles inserted by postprocessors, which is what we want almost always.

Let me know if there's something that I should fix on branch.

(closes #66)