### PR TITLE
Fixes to issues introduced by the default css reposition

### DIFF
--- a/html5css3/postprocessors.py
+++ b/html5css3/postprocessors.py
@@ -71,7 +71,6 @@ def deckjs(tree, embed=True, params=None):
     def path(*args):
         return join_path("thirdparty", "deckjs", *args)
 
-    head.remove(head.find("./style"))
     add_class(body, "deck-container")
 
     for section in tree.findall(".//section"):

--- a/html5css3/rst2html5-reveal.css
+++ b/html5css3/rst2html5-reveal.css
@@ -1,3 +1,7 @@
+body.reveal {
+    margin: 0;
+}
+
 .hide-title>header{
  display: none
 }


### PR DESCRIPTION
Looks like my previous pull request introduced some issues when using the `--deck-js` and `--reveal-js` options with the default styles; this pull request intends to fix those.

Please give it a look and let me know in any case!