### PR TITLE
Fix #72: raw-directive has problems with multiple and nested tags.

### DIFF
--- a/html5css3/__init__.py
+++ b/html5css3/__init__.py
@@ -27,6 +27,8 @@ except ImportError:
     Image = None
 
 from docutils import frontend, nodes, utils, writers, languages
+import xml.etree.ElementTree
+
 from . import html
 from .html import *
 # import default post processors so they register
@@ -327,9 +329,13 @@ def swallow_childs(node, translator):
     return Span(class_="remove-me")
 
 def raw(node, translator):
-    result = html.raw(node.astext())
-    translator._append(result, node)
-    return result
+    el = xml.etree.ElementTree.fromstring('<div>' + node.astext() + '</div>')
+    children = [html.tag_from_element(c) for c in el]
+    for child in children:
+        translator._append(child, node)
+    node.children[:] = []
+    return children[-1]
+
 
 NODES = {
     "abbreviation": Abbr,

--- a/html5css3/html.py
+++ b/html5css3/html.py
@@ -224,25 +224,26 @@ def create_tags(ctx):
 
 create_tags(globals())
 
-class Raw(Element):
-    def __init__(self, content):
-        el = ET.fromstring(content)
-        Element.__init__(self, el.tag, el.attrib)
-        self.text = el.text
-        self.tail = el.tail
 
-    def __repr__(self):
-        return ET.tostring(self.content, "utf-8", "html")
+def tag_from_element(el):
+    """
+    Convert an Element into a Tag.
 
-    def __str__(self):
-        "return a string representation"
-        return ET.tostring(self.content, "utf-8", "html")
+    ``el`` is an instance of ``Element``. Returns an instance of the
+    corresponding subclass of ``TagBase``.
+    """
+    try:
+        cls = globals()[el.tag.title()]
+        if not issubclass(cls, TagBase):
+            raise KeyError()
+    except KeyError:
+        raise ValueError("TagBase doesn't have a subclass for '%s'." % el.tag)
+    children = [tag_from_element(c) for c in el]
+    tag = cls(*children, **el.attrib)
+    tag.text = el.text
+    tag.tail = el.tail
+    return tag
 
-    def append(self, content):
-        pass
-
-def raw(content):
-    return Raw(content)
 
 DOCTYPE = "<!DOCTYPE html>"
 


### PR DESCRIPTION
This PR fixes issue #72 (raw-directive has problems with multiple and nested tags).

The previous code for handling raw-directives used a special `Raw` element class. To support multiple tags I had to change this so that raw-directives are now handled specially in the higher level code (see `html5css3.raw`). The fix for nested tags is as described in the original bug report.