### PR TITLE
Fix #73: Crash with non-ASCII characters in attributes

### DIFF
--- a/html5css3/html.py
+++ b/html5css3/html.py
@@ -36,7 +36,7 @@ def to_str(value):
     return unicode(value)
 
 def escape_attrs(node):
-    node.attrib = dict([(key.rstrip("_"), str(val))
+    node.attrib = dict([(key.rstrip("_"), unicode(val))
         for (key, val) in node.attrib.items()])
 
     for child in node:


### PR DESCRIPTION
This PR fixes #73 (Crash with non-ASCII characters in attributes). Due to #62 I haven't been able to test this on Python 3, but it works on Python 2.7.