### PR TITLE
Fix #75: Add test framework.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 build
 dist
 rst2html5_tools.egg-info
+.tox
+.cache

--- a/README.rst
+++ b/README.rst
@@ -158,6 +158,18 @@ example of video directive
 * http://marianoguerra.github.com/rst2html5/output/videos.html
 
 
+test it
+-------
+We use `tox <https://tox.readthedocs.org>`_ to run our test suite. After installing *tox* you can execute the tests by running
+
+::
+    tox
+
+in the project's root directory.
+
+The test cases can be found in ``html5css3/tests.py``.
+
+
 want to contribute ?
 --------------------
 

--- a/html5css3/tests.py
+++ b/html5css3/tests.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# vim: set fileencoding=utf-8 :
+
+# Author: Florian Brucker <mail@florianbrucker.de>
+# Copyright: This module has been placed in the public domain.
+
+"""
+Tests for ``html5css3``.
+
+These tests are intended to be run via pytest_. To
+execute all ``html5css3`` tests on all supported Python versions simply
+run ``tox`` in the project's root directory (this requires tox_).
+
+.. _pytest: http://pytest.org
+.. _tox: https://tox.readthedocs.org
+"""
+
+from __future__ import unicode_literals
+
+import textwrap
+import re
+
+from docutils.core import publish_string
+
+from . import Writer
+
+
+#
+# Utility Functions
+#
+
+def remove_whitespace_lines(s):
+    """
+    Remove whitespace-only lines at the beginning and end of a string.
+    """
+    return re.sub(r'^([^\S\n]*\n)*', '', re.sub(r'(\n[^\S\n]*)*$', '', s))
+
+
+def rst2html(rst, only_body=True):
+    """
+    Convert RST to HTML.
+
+    If ``only_body`` is true then only the HTML code between the opening
+    and closing ``body`` tag is returned.
+    """
+    result = publish_string(
+        source=rst,
+        writer=Writer(),
+        writer_name='html5css3',
+        settings_overrides={'input_encoding': 'utf8'},
+    ).decode('utf8')
+    if only_body:
+        start = result.index('<body>') + 6
+        stop = result.rindex('</body>')
+        result = result[start:stop]
+    return result
+
+
+def assert_rst(rst, html, only_body=True, dedent=True):
+    """
+    Assert that RST is correctly converted to HTML.
+
+    The RST code in ``rst`` is converted to HTML and compared with the
+    HTML code in ``html``. If they do not match an ``AssertionError``
+    is raised.
+
+    If ``only_body`` is true then only the generated HTML code between
+    the opening and closing ``body`` tag is compared to the expected
+    result.
+
+    If ``dedent`` is true then ``rst`` and ``html`` are preprocessed as
+    follows: First, empty and white-space lines at the beginning and end
+    are removed. The remaining lines are then dedented, i.e. common
+    leading whitespace is stripped. This allows for more flexibility
+    when formatting test source code.
+    """
+    __tracebackhide__ = True  # Hide this function in py.test tracebacks
+    if dedent:
+        rst = textwrap.dedent(remove_whitespace_lines(rst))
+        html = textwrap.dedent(remove_whitespace_lines(html))
+    result = rst2html(rst, only_body)
+    assert result == html
+
+
+#
+# Tests
+#
+
+
+def test_multiple_and_nested_tags_in_raw():
+    """
+    Multiple and nested tags in raw-directives.
+    """
+    # See https://github.com/marianoguerra/rst2html5/issues/72
+    assert_rst("""
+        .. raw:: html
+
+            <p id="d1">x<a href="foo">y</a>z</p>
+            <p>a<em class="bar">b</em>c</p>
+            foo <b>bar</b>
+        """, """
+            <p id="d1">x<a href="foo">y</a>z</p>
+            <p>a<em class="bar">b</em>c</p>
+            foo <b>bar</b>
+        """)
+
+
+def test_non_ascii_chars_in_attributes():
+    """
+    Non-ASCII characters in HTML attributes.
+    """
+    # See https://github.com/marianoguerra/rst2html5/issues/73
+    assert_rst("""
+        .. figure:: image.png
+            :alt: ö
+        """, """
+            <figure><img alt="ö" src="image.png"></figure>
+        """)
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --pyargs html5css3.tests
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py34
+
+[testenv]
+commands = py.test
+deps =
+    pytest
+    docutils
+


### PR DESCRIPTION
This PR fixes #75 (Add test framework).

I've added the necessary configuration for running tests via [pytest](http://pytest.org) and [tox](https://tox.readthedocs.org). Only the latter needs to be manually installed, since tox will automatically install pytest if necessary.

The test cases can be found in `html5css3/tests.py`. The README has been updated with instructions on how to run the tests.

Currently there are only two test cases (for checking that #72 and #73 are fixed), but adding new test cases should be easy using the utility functions that I've added to `html5css3.tests` (in particular `assert_rst`).

Currently tests are run against Python 2.7 and Python 3.4. Feel free to add more Python versions (e.g. Python 3.5) to the list in `tox.ini`. Obviously you will need to locally install any Python version that you want to run the tests on (tox will ignore versions that are not installed locally, so there is little harm in adding more versions).