### PR TITLE
Fix missing files in RevealJS #82

### DIFF
--- a/html5css3/postprocessors.py
+++ b/html5css3/postprocessors.py
@@ -131,7 +131,7 @@ def revealjs(tree, embed=True, params=None):
     head = tree[0]
     body = tree[1]
     params = params or {}
-    theme_name = params.pop("theme", "default") + ".css"
+    theme_name = params.pop("theme", "league") + ".css"
     theme_base_dir = params.pop("themepath", None)
     printpdf = params.pop("printpdf", False)
 
@@ -161,9 +161,9 @@ def revealjs(tree, embed=True, params=None):
         head.append(css(path("css", "print", "pdf.css"), embed))
 
     # <script src="lib/js/head.min.js"></script>
-    # <script src="js/reveal.min.js"></script>
+    # <script src="js/reveal.js"></script>
     body.append(js(path("lib", "js", "head.min.js"), embed))
-    body.append(js(path("js", "reveal.min.js"), embed))
+    body.append(js(path("js", "reveal.js"), embed))
 
     head.append(css("rst2html5-reveal.css", embed))
 


### PR DESCRIPTION
default.css renamed to league.css after https://github.com/hakimel/reveal.js/issues/1018
and https://github.com/hakimel/reveal.js/commit/dc215a244174b88587ca032a68c172010235d154

also minified version (reveal.min.js) is not tracked anymore
https://github.com/hakimel/reveal.js/issues/1118
https://github.com/hakimel/reveal.js/pull/783